### PR TITLE
Numpy2.0

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,3 @@
-PYTHON = .venv/bin/python
-
 SUBDIRS = src test
 
 EXTRA_DIST =  detectorbank.i python_docstrings.i numpy.i \

--- a/Makefile.am
+++ b/Makefile.am
@@ -77,23 +77,25 @@ uninstall-docs-local:
 if DO_SWIG_BINDINGS
 SWIGINPUTS = documentation.i detectorbank.i
 SWIGOUTPUTS = detectorbank_wrap.cpp detectorbank.py
-SWIGFILES = $(SWIGINPUTS) $(SWIGOUTPUTS)
-MOSTLYCLEANFILES += documentation.i $(SWIGOUTPUTS) stamp-py stamp-lib
+SWIGFILES = $(SWIGINPUTS) $(SWIGOUTPUTS) stamp-wheel
+MOSTLYCLEANFILES += documentation.i $(SWIGOUTPUTS) stamp-py stamp-lib stamp-wheel
 
 documentation.i: $(DOCSTAMP)
 	$(PYTHON) $(srcdir)/doxy2swig.py $(DX_DOCDIR)/xml/index.xml ./documentation.i
 	$(PYTHON) $(srcdir)/doc_fix.py ./documentation.i
 
-all-local:  $(SWIGOUTPUTS)
+all-local:  $(SWIGFILES)
 
 # If stamp-lib (touched by library build) doesn't exist yet, don't try to make it
 stamp-lib:
 
-# All of the swig targets get build with a single command,
+# All of the swig targets get built with a single command,
 # so this is a grouped target.
 $(SWIGOUTPUTS) &: $(SWIGINPUTS) stamp-lib
 	$(SWIG) -python -c++ -o detectorbank_wrap.cpp -I$(srcdir)/src $(srcdir)/detectorbank.i
-	$(PYTHON) -m build -n
+
+stamp-wheel: $(SWIGOUTPUTS)
+	$(PYTHON) -m build -n && find . -name \*.whl -ls > stamp-wheel
 
 
 # installation requires SWIG to be complete.

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,3 +1,5 @@
+PYTHON = .venv/bin/python
+
 SUBDIRS = src test
 
 EXTRA_DIST =  detectorbank.i python_docstrings.i numpy.i \
@@ -93,7 +95,8 @@ stamp-lib:
 # so this is a grouped target.
 $(SWIGOUTPUTS) &: $(SWIGINPUTS) stamp-lib
 	$(SWIG) -python -c++ -o detectorbank_wrap.cpp -I$(srcdir)/src $(srcdir)/detectorbank.i
-	$(PYTHON) -m build
+	$(PYTHON) -m build -n
+
 
 # installation requires SWIG to be complete.
 install-exec-local: $(SWIGOUTPUTS)

--- a/README.md
+++ b/README.md
@@ -68,16 +68,16 @@ mkdir -p build
 cd build
 ```
 
-If you want to build the Python extension, you'll need to create a virtual environment
-(or use an existing one)
-```
+The Python extension requires [numpy](https://numpy.org/); your system numpy version
+will be used by default. However, this may lead to issues if your system NumPy version
+is different from the version you use in a virtual environment. If you want to build
+the `detectorbank` extension to work with a specifc NumPy version, we recommend that
+you build it in a venv with your required NumPy version installed, for example:
+```bash
 python -m venv .venv
 source .venv/bin/activate
 python -m pip install numpy build wheel setuptools
 ```
-
-Note that `pip install numpy` will install numpy version 2.x. If you want to build
-Detectorbank to work with numpy 1.x, you'll need to specify your required numpy version.
 
 If you're using a virtual environment, pass the path to the python executable to `configure`,
 for example

--- a/README.md
+++ b/README.md
@@ -74,9 +74,10 @@ is different from the version you use in a virtual environment. If you want to b
 the `detectorbank` extension to work with a specifc NumPy version, we recommend that
 you build it in a venv with your required NumPy version installed, for example:
 ```bash
+# optional step to build against a specific numpy version
 python -m venv .venv
 source .venv/bin/activate
-python -m pip install "numpy<2" build wheel setuptools
+python -m pip install "numpy>=2" build wheel setuptools
 ```
 
 Next configure the build system

--- a/README.md
+++ b/README.md
@@ -67,6 +67,17 @@ a new directory.
 mkdir -p build
 cd build
 ../configure
+```
+
+If you want to build the Python extension, you'll need to create a virtual environment
+```
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install numpy build wheel
+```
+
+Then build Detectorbank
+```
 make
 ```
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ python -m pip install numpy build wheel
 If you're using a virtual environment, pass the path to the python executable to `configure`,
 for example
 ```
-../configure PYTHON=./.venv/bin/python
+../configure PYTHON=.venv/bin/python
 ```
 Otherwise,
 ```

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ make
 ```
 
 Optionally build and run the unit tests. Note that the Python tests execute in their own
-virtual environemtn, so before running `make check`, you may need to `deactivate` your
+virtual environment, so before running `make check`, you may need to `deactivate` your
 current venv.
 ```
 make check

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ mkdir -p build
 cd build
 ```
 
-The Python extension requires [numpy](https://numpy.org/); your system numpy version
+The Python extension requires [NumPy](https://numpy.org/); your system numpy version
 will be used by default. However, this may lead to issues if your system NumPy version
 is different from the version you use in a virtual environment. If you want to build
 the `detectorbank` extension to work with a specifc NumPy version, we recommend that
@@ -76,51 +76,48 @@ you build it in a venv with your required NumPy version installed, for example:
 ```bash
 python -m venv .venv
 source .venv/bin/activate
-python -m pip install numpy build wheel setuptools
+python -m pip install "numpy<2" build wheel setuptools
 ```
 
-If you're using a virtual environment, pass the path to the python executable to `configure`,
-for example
-```
-../configure PYTHON=.venv/bin/python
-```
-Otherwise, to use the system Python,
-```
+Next configure the build system
+```bash
 ../configure
 ```
-
-Then build Detectorbank
+Note that if you're using a virtual environment, pass the path to the python executable
+to `configure`, for example
+```bash
+../configure PYTHON=.venv/bin/python
 ```
+
+Then build `DetectorBank`
+```bash
 make
 ```
 
 Optionally build and run the unit tests. Note that the Python tests execute in their own
 virtual environment, so before running `make check`, you may need to `deactivate` your
-current venv.
-```
+build venv.
+```bash
 make check
 ```
 
 Note that to run a single test, you can look in `tests/Makefile.am` then supply a replacement for TESTS naming
-only those you wish to run, e.g.:
-
-```
+only those you wish to run, e.g.
+```bash
 make check TESTS='Pytests'
 ```
 
 The results of the checks are written in test/test-suite.log
-
-```
+```bash
 sudo make install
 ```
 
 On some platforms you may have to add `/usr/local/lib/` to your `LD_LIBRARY_PATH`
-```
+```bash
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib/
 ```
 and/or refresh the shared object cache:
-
-```
+```bash
 sudo ldconfig
 ```
 
@@ -128,9 +125,9 @@ System-wide installation of Python packages via pip is deprecated, but you
 can install `detectorbank` in a Python virtual environment via `pip` from 
 the wheel in `build/dist`. 
 For example, to create a new venv and install `detectorbank`, starting from the `build` dir:
-```
+```bash
 # note that the exact name of the wheel depends on the python version you are using
-DETBANK_WHEEL=`readlink -f dist/detectorbank-1.0.0-cp311-cp311-linux_x86_64.whl`
+DETBANK_WHEEL=`readlink -f dist/detectorbank-1.0.0-cp312-cp312-linux_x86_64.whl`
 cd ~
 mkdir detbank
 cd detbank
@@ -143,15 +140,13 @@ optional/only required on some platforms.
 
 Perhaps test that the library's been installed properly by asking
 for the compilation flags
-
-```
+```bash
 ( cd ; pkg-config detectorbank --cflags --libs )
 ```
 
 Documentation is built in the doxygen-doc subdirectory and installed
-in $(docdir)/html. The default top page for the documentation is:
-
-```
+in $(docdir)/html. The default top page for the documentation is
+```bash
 /usr/local/share/doc/detectorbank/html/index.html
 ```
 
@@ -160,9 +155,8 @@ pass the `--without-swig` to the configure command. Note that Python3
 is still required to build the library.
 
 You can build for debugging by defining the C preprocesor macro DEBUG when
-compiling. For example:
-
-```
+compiling. For example
+```bash
 ../configure CPPFLAGS=-DDEBUG=2
 ```
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ If you want to build the Python extension, you'll need to create a virtual envir
 ```
 python -m venv .venv
 source .venv/bin/activate
-python -m pip install numpy build wheel
+python -m pip install numpy build wheel setuptools
 ```
 
 Note that `pip install numpy` will install numpy version 2.x. If you want to build

--- a/README.md
+++ b/README.md
@@ -76,12 +76,15 @@ source .venv/bin/activate
 python -m pip install numpy build wheel
 ```
 
+Note that `pip install numpy` will install numpy version 2.x. If you want to build
+Detectorbank to work with numpy 1.x, you'll need to specify your required numpy version.
+
 If you're using a virtual environment, pass the path to the python executable to `configure`,
 for example
 ```
 ../configure PYTHON=.venv/bin/python
 ```
-Otherwise,
+Otherwise, to use the system Python,
 ```
 ../configure
 ```
@@ -91,8 +94,9 @@ Then build Detectorbank
 make
 ```
 
-Optionally build and run the unit tests
-
+Optionally build and run the unit tests. Note that the Python tests execute in their own
+virtual environemtn, so before running `make check`, you may need to `deactivate` your
+current venv.
 ```
 make check
 ```

--- a/README.md
+++ b/README.md
@@ -66,14 +66,24 @@ a new directory.
 ```
 mkdir -p build
 cd build
-../configure
 ```
 
 If you want to build the Python extension, you'll need to create a virtual environment
+(or use an existing one)
 ```
 python -m venv .venv
 source .venv/bin/activate
 python -m pip install numpy build wheel
+```
+
+If you're using a virtual environment, pass the path to the python executable to `configure`,
+for example
+```
+../configure PYTHON=./.venv/bin/python
+```
+Otherwise,
+```
+../configure
 ```
 
 Then build Detectorbank

--- a/configure.ac
+++ b/configure.ac
@@ -106,9 +106,23 @@ DX_INIT_DOXYGEN(Detectorbank, ${builddir}/Doxyfile)
 # Tell (PDF)LaTeX the directory where external graphics live
 AC_SUBST([docgraphics],${srcdir}/graphics/)
 
+## Changes:
+# below, I've tried to set the numpy include dir, then combine this with the
+# radidxml include dir into the EXTRA_CXXFLAGS var
+# which I think works, it's just the NUMPY_INCLUDE thing that doesn't
+# we also should use a variable for the python executable, as depending on the system
+# or user setup, it could be `python`, `python3` or `path/to/venv/bin/python`
+
 # Get abspath of top srcdir (assuming we're calling this script from top_srcdir/build)
 ABS_TOP_DIR="$(pwd)/.."
-RXML_CXXFLAGS="-I${ABS_TOP_DIR}/include"
-AC_SUBST(AM_CXXFLAGS, $RXML_CXXFLAGS)
+# RXML_CXXFLAGS="-I${ABS_TOP_DIR}/include"
+# AC_SUBST(AM_CXXFLAGS, $RXML_CXXFLAGS)
+
+NUMPY_INCLUDE="$(python -c 'import numpy as np;from pathlib import Path;print(Path(np.__file__).parent.joinpath("core", "include"))')"
+# NUMPY_CXXFLAGS="-I${NUMPY_INCLUDE}"
+
+EXTRA_CXXFLAGS="-I${ABS_TOP_DIR}/include -I${NUMPY_INCLUDE}"
+
+AC_SUBST(AM_CXXFLAGS, $EXTRA_CXXFLAGS)
 
 AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -79,7 +79,11 @@ AS_IF([test "x$with_swig" = "xyes"],
       ],
       [AC_MSG_NOTICE([SWIG interface generation of python bindings is disabled])])
 
-AM_CONDITIONAL([DO_SWIG_BINDINGS], [test "x$with_swig" = "xyes"])         
+AM_CONDITIONAL([DO_SWIG_BINDINGS], [test "x$with_swig" = "xyes"])
+
+AC_ARG_VAR([python],
+    [Python executable to use]
+)
 
 AC_SUBST([PACKAGE_VERSION_MAJOR],package_version_major)
 AC_SUBST([PACKAGE_VERSION_MINOR],package_version_minor)

--- a/configure.ac
+++ b/configure.ac
@@ -85,6 +85,8 @@ AC_ARG_VAR([python],
     [Python executable to use]
 )
 
+AC_SUBST(PYTHON, $(realpath -s $PYTHON))
+
 AC_SUBST([PACKAGE_VERSION_MAJOR],package_version_major)
 AC_SUBST([PACKAGE_VERSION_MINOR],package_version_minor)
 AC_SUBST([PACKAGE_VERSION_MICRO],package_version_micro)

--- a/configure.ac
+++ b/configure.ac
@@ -106,23 +106,9 @@ DX_INIT_DOXYGEN(Detectorbank, ${builddir}/Doxyfile)
 # Tell (PDF)LaTeX the directory where external graphics live
 AC_SUBST([docgraphics],${srcdir}/graphics/)
 
-## Changes:
-# below, I've tried to set the numpy include dir, then combine this with the
-# radidxml include dir into the EXTRA_CXXFLAGS var
-# which I think works, it's just the NUMPY_INCLUDE thing that doesn't
-# we also should use a variable for the python executable, as depending on the system
-# or user setup, it could be `python`, `python3` or `path/to/venv/bin/python`
-
 # Get abspath of top srcdir (assuming we're calling this script from top_srcdir/build)
 ABS_TOP_DIR="$(pwd)/.."
-# RXML_CXXFLAGS="-I${ABS_TOP_DIR}/include"
-# AC_SUBST(AM_CXXFLAGS, $RXML_CXXFLAGS)
-
-NUMPY_INCLUDE="$(python -c 'import numpy as np;from pathlib import Path;print(Path(np.__file__).parent.joinpath("core", "include"))')"
-# NUMPY_CXXFLAGS="-I${NUMPY_INCLUDE}"
-
-EXTRA_CXXFLAGS="-I${ABS_TOP_DIR}/include -I${NUMPY_INCLUDE}"
-
-AC_SUBST(AM_CXXFLAGS, $EXTRA_CXXFLAGS)
+RXML_CXXFLAGS="-I${ABS_TOP_DIR}/include"
+AC_SUBST(AM_CXXFLAGS, $RXML_CXXFLAGS)
 
 AC_OUTPUT

--- a/numpy.i
+++ b/numpy.i
@@ -48,7 +48,7 @@
 
 %fragment("NumPy_Backward_Compatibility", "header")
 {
-%#if NPY_API_VERSION < 0x00000007
+%#if NPY_API_VERSION < NPY_1_7_API_VERSION
 %#define NPY_ARRAY_DEFAULT NPY_DEFAULT
 %#define NPY_ARRAY_FARRAY  NPY_FARRAY
 %#define NPY_FORTRANORDER  NPY_FORTRAN
@@ -69,7 +69,7 @@
 {
 /* Macros to extract array attributes.
  */
-%#if NPY_API_VERSION < 0x00000007
+%#if NPY_API_VERSION < NPY_1_7_API_VERSION
 %#define is_array(a)            ((a) && PyArray_Check((PyArrayObject*)a))
 %#define array_type(a)          (int)(PyArray_TYPE((PyArrayObject*)a))
 %#define array_numdims(a)       (((PyArrayObject*)a)->nd)
@@ -80,7 +80,9 @@
 %#define array_data(a)          (((PyArrayObject*)a)->data)
 %#define array_descr(a)         (((PyArrayObject*)a)->descr)
 %#define array_flags(a)         (((PyArrayObject*)a)->flags)
+%#define array_clearflags(a,f)  (((PyArrayObject*)a)->flags) &= ~f
 %#define array_enableflags(a,f) (((PyArrayObject*)a)->flags) = f
+%#define array_is_fortran(a)    (PyArray_ISFORTRAN((PyArrayObject*)a))
 %#else
 %#define is_array(a)            ((a) && PyArray_Check(a))
 %#define array_type(a)          PyArray_TYPE((PyArrayObject*)a)
@@ -93,10 +95,11 @@
 %#define array_descr(a)         PyArray_DESCR((PyArrayObject*)a)
 %#define array_flags(a)         PyArray_FLAGS((PyArrayObject*)a)
 %#define array_enableflags(a,f) PyArray_ENABLEFLAGS((PyArrayObject*)a,f)
+%#define array_clearflags(a,f)  PyArray_CLEARFLAGS((PyArrayObject*)a,f)
+%#define array_is_fortran(a)    (PyArray_IS_F_CONTIGUOUS((PyArrayObject*)a))
 %#endif
 %#define array_is_contiguous(a) (PyArray_ISCONTIGUOUS((PyArrayObject*)a))
 %#define array_is_native(a)     (PyArray_ISNOTSWAPPED((PyArrayObject*)a))
-%#define array_is_fortran(a)    (PyArray_IS_F_CONTIGUOUS((PyArrayObject*)a))
 }
 
 /**********************************************************************/
@@ -111,19 +114,14 @@
     if (py_obj == NULL          ) return "C NULL value";
     if (py_obj == Py_None       ) return "Python None" ;
     if (PyCallable_Check(py_obj)) return "callable"    ;
-    if (PyString_Check(  py_obj)) return "string"      ;
-    if (PyInt_Check(     py_obj)) return "int"         ;
+    if (PyBytes_Check(   py_obj)) return "string"      ;
+    if (PyLong_Check(    py_obj)) return "int"         ;
     if (PyFloat_Check(   py_obj)) return "float"       ;
     if (PyDict_Check(    py_obj)) return "dict"        ;
     if (PyList_Check(    py_obj)) return "list"        ;
     if (PyTuple_Check(   py_obj)) return "tuple"       ;
-%#if PY_MAJOR_VERSION < 3
-    if (PyFile_Check(    py_obj)) return "file"        ;
-    if (PyModule_Check(  py_obj)) return "module"      ;
-    if (PyInstance_Check(py_obj)) return "instance"    ;
-%#endif
 
-    return "unkown type";
+    return "unknown type";
   }
 
   /* Given a NumPy typecode, return a string describing the type.
@@ -167,13 +165,11 @@
     return PyArray_EquivTypenums(actual_type, desired_type);
   }
 
-%#ifdef SWIGPY_USE_CAPSULE
-  void free_cap(PyObject * cap)
+void free_cap(PyObject * cap)
   {
     void* array = (void*) PyCapsule_GetPointer(cap,SWIGPY_CAPSULE_NAME);
     if (array != NULL) free(array);
   }
-%#endif
 
 
 }
@@ -295,7 +291,11 @@
       Py_INCREF(array_descr(ary));
       result = (PyArrayObject*) PyArray_FromArray(ary,
                                                   array_descr(ary),
+%#if NPY_API_VERSION < NPY_1_7_API_VERSION
+                                                  NPY_FORTRANORDER);
+%#else
                                                   NPY_ARRAY_F_CONTIGUOUS);
+%#endif
       *is_new_object = 1;
     }
     return result;
@@ -480,7 +480,7 @@
   {
     int i;
     int success = 1;
-    int len;
+    size_t len;
     char desired_dims[255] = "[";
     char s[255];
     char actual_dims[255] = "[";
@@ -522,7 +522,7 @@
     return success;
   }
 
-  /* Require the given PyArrayObject to to be Fortran ordered.  If the
+  /* Require the given PyArrayObject to be Fortran ordered.  If the
    * the PyArrayObject is already Fortran ordered, do nothing.  Else,
    * set the Fortran ordering flag and recompute the strides.
    */
@@ -533,7 +533,13 @@
     int i;
     npy_intp * strides = array_strides(ary);
     if (array_is_fortran(ary)) return success;
+    int n_non_one = 0;
     /* Set the Fortran ordered flag */
+    const npy_intp *dims = array_dimensions(ary);
+    for (i=0; i < nd; ++i)
+      n_non_one += (dims[i] != 1) ? 1 : 0;
+    if (n_non_one > 1)
+      array_clearflags(ary,NPY_ARRAY_CARRAY);
     array_enableflags(ary,NPY_ARRAY_FARRAY);
     /* Recompute the strides */
     strides[0] = strides[nd-1];
@@ -1994,7 +2000,7 @@
   (PyObject* array = NULL)
 {
   npy_intp dims[1];
-  if (!PyInt_Check($input))
+  if (!PyLong_Check($input))
   {
     const char* typestring = pytype_string($input);
     PyErr_Format(PyExc_TypeError,
@@ -2002,7 +2008,8 @@
                  typestring);
     SWIG_fail;
   }
-  $2 = (DIM_TYPE) PyInt_AsLong($input);
+  $2 = (DIM_TYPE) PyLong_AsSsize_t($input);
+  if ($2 == -1 && PyErr_Occurred()) SWIG_fail;
   dims[0] = (npy_intp) $2;
   array = PyArray_SimpleNew(1, dims, DATA_TYPECODE);
   if (!array) SWIG_fail;
@@ -2022,7 +2029,7 @@
   (PyObject* array = NULL)
 {
   npy_intp dims[1];
-  if (!PyInt_Check($input))
+  if (!PyLong_Check($input))
   {
     const char* typestring = pytype_string($input);
     PyErr_Format(PyExc_TypeError,
@@ -2030,7 +2037,8 @@
                  typestring);
     SWIG_fail;
   }
-  $1 = (DIM_TYPE) PyInt_AsLong($input);
+  $1 = (DIM_TYPE) PyLong_AsSsize_t($input);
+  if ($1 == -1 && PyErr_Occurred()) SWIG_fail;
   dims[0] = (npy_intp) $1;
   array = PyArray_SimpleNew(1, dims, DATA_TYPECODE);
   if (!array) SWIG_fail;
@@ -2449,13 +2457,9 @@
 
   if (!array) SWIG_fail;
 
-%#ifdef SWIGPY_USE_CAPSULE
-    PyObject* cap = PyCapsule_New((void*)(*$1), SWIGPY_CAPSULE_NAME, free_cap);
-%#else
-    PyObject* cap = PyCObject_FromVoidPtr((void*)(*$1), free);
-%#endif
+PyObject* cap = PyCapsule_New((void*)(*$1), SWIGPY_CAPSULE_NAME, free_cap);
 
-%#if NPY_API_VERSION < 0x00000007
+%#if NPY_API_VERSION < NPY_1_7_API_VERSION
   PyArray_BASE(array) = cap;
 %#else
   PyArray_SetBaseObject(array,cap);
@@ -2483,13 +2487,9 @@
 
   if (!array) SWIG_fail;
 
-%#ifdef SWIGPY_USE_CAPSULE
-    PyObject* cap = PyCapsule_New((void*)(*$1), SWIGPY_CAPSULE_NAME, free_cap);
-%#else
-    PyObject* cap = PyCObject_FromVoidPtr((void*)(*$1), free);
-%#endif
+PyObject* cap = PyCapsule_New((void*)(*$2), SWIGPY_CAPSULE_NAME, free_cap);
 
-%#if NPY_API_VERSION < 0x00000007
+%#if NPY_API_VERSION < NPY_1_7_API_VERSION
   PyArray_BASE(array) = cap;
 %#else
   PyArray_SetBaseObject(array,cap);
@@ -2518,13 +2518,9 @@
 
   if (!array) SWIG_fail;
 
-%#ifdef SWIGPY_USE_CAPSULE
-    PyObject* cap = PyCapsule_New((void*)(*$1), SWIGPY_CAPSULE_NAME, free_cap);
-%#else
-    PyObject* cap = PyCObject_FromVoidPtr((void*)(*$1), free);
-%#endif
+PyObject* cap = PyCapsule_New((void*)(*$1), SWIGPY_CAPSULE_NAME, free_cap);
 
-%#if NPY_API_VERSION < 0x00000007
+%#if NPY_API_VERSION < NPY_1_7_API_VERSION
   PyArray_BASE(array) = cap;
 %#else
   PyArray_SetBaseObject(array,cap);
@@ -2553,13 +2549,9 @@
 
   if (!array) SWIG_fail;
 
-%#ifdef SWIGPY_USE_CAPSULE
-    PyObject* cap = PyCapsule_New((void*)(*$1), SWIGPY_CAPSULE_NAME, free_cap);
-%#else
-    PyObject* cap = PyCObject_FromVoidPtr((void*)(*$1), free);
-%#endif
+PyObject* cap = PyCapsule_New((void*)(*$3), SWIGPY_CAPSULE_NAME, free_cap);
 
-%#if NPY_API_VERSION < 0x00000007
+%#if NPY_API_VERSION < NPY_1_7_API_VERSION
   PyArray_BASE(array) = cap;
 %#else
   PyArray_SetBaseObject(array,cap);
@@ -2588,13 +2580,9 @@
 
   if (!array || !require_fortran(array)) SWIG_fail;
 
-%#ifdef SWIGPY_USE_CAPSULE
-    PyObject* cap = PyCapsule_New((void*)(*$1), SWIGPY_CAPSULE_NAME, free_cap);
-%#else
-    PyObject* cap = PyCObject_FromVoidPtr((void*)(*$1), free);
-%#endif
+PyObject* cap = PyCapsule_New((void*)(*$1), SWIGPY_CAPSULE_NAME, free_cap);
 
-%#if NPY_API_VERSION < 0x00000007
+%#if NPY_API_VERSION < NPY_1_7_API_VERSION
   PyArray_BASE(array) = cap;
 %#else
   PyArray_SetBaseObject(array,cap);
@@ -2623,13 +2611,9 @@
 
   if (!array || !require_fortran(array)) SWIG_fail;
 
-%#ifdef SWIGPY_USE_CAPSULE
-    PyObject* cap = PyCapsule_New((void*)(*$1), SWIGPY_CAPSULE_NAME, free_cap);
-%#else
-    PyObject* cap = PyCObject_FromVoidPtr((void*)(*$1), free);
-%#endif
+PyObject* cap = PyCapsule_New((void*)(*$3), SWIGPY_CAPSULE_NAME, free_cap);
 
-%#if NPY_API_VERSION < 0x00000007
+%#if NPY_API_VERSION < NPY_1_7_API_VERSION
   PyArray_BASE(array) = cap;
 %#else
   PyArray_SetBaseObject(array,cap);
@@ -2660,13 +2644,9 @@
 
   if (!array) SWIG_fail;
 
-%#ifdef SWIGPY_USE_CAPSULE
-    PyObject* cap = PyCapsule_New((void*)(*$1), SWIGPY_CAPSULE_NAME, free_cap);
-%#else
-    PyObject* cap = PyCObject_FromVoidPtr((void*)(*$1), free);
-%#endif
+PyObject* cap = PyCapsule_New((void*)(*$1), SWIGPY_CAPSULE_NAME, free_cap);
 
-%#if NPY_API_VERSION < 0x00000007
+%#if NPY_API_VERSION < NPY_1_7_API_VERSION
   PyArray_BASE(array) = cap;
 %#else
   PyArray_SetBaseObject(array,cap);
@@ -2697,13 +2677,9 @@
 
   if (!array) SWIG_fail;
 
-%#ifdef SWIGPY_USE_CAPSULE
-    PyObject* cap = PyCapsule_New((void*)(*$1), SWIGPY_CAPSULE_NAME, free_cap);
-%#else
-    PyObject* cap = PyCObject_FromVoidPtr((void*)(*$1), free);
-%#endif
+PyObject* cap = PyCapsule_New((void*)(*$4), SWIGPY_CAPSULE_NAME, free_cap);
 
-%#if NPY_API_VERSION < 0x00000007
+%#if NPY_API_VERSION < NPY_1_7_API_VERSION
   PyArray_BASE(array) = cap;
 %#else
   PyArray_SetBaseObject(array,cap);
@@ -2734,13 +2710,9 @@
 
   if (!array || !require_fortran(array)) SWIG_fail;
 
-%#ifdef SWIGPY_USE_CAPSULE
-    PyObject* cap = PyCapsule_New((void*)(*$1), SWIGPY_CAPSULE_NAME, free_cap);
-%#else
-    PyObject* cap = PyCObject_FromVoidPtr((void*)(*$1), free);
-%#endif
+PyObject* cap = PyCapsule_New((void*)(*$1), SWIGPY_CAPSULE_NAME, free_cap);
 
-%#if NPY_API_VERSION < 0x00000007
+%#if NPY_API_VERSION < NPY_1_7_API_VERSION
   PyArray_BASE(array) = cap;
 %#else
   PyArray_SetBaseObject(array,cap);
@@ -2771,13 +2743,9 @@
 
   if (!array || !require_fortran(array)) SWIG_fail;
 
-%#ifdef SWIGPY_USE_CAPSULE
-    PyObject* cap = PyCapsule_New((void*)(*$1), SWIGPY_CAPSULE_NAME, free_cap);
-%#else
-    PyObject* cap = PyCObject_FromVoidPtr((void*)(*$1), free);
-%#endif
+PyObject* cap = PyCapsule_New((void*)(*$4), SWIGPY_CAPSULE_NAME, free_cap);
 
-%#if NPY_API_VERSION < 0x00000007
+%#if NPY_API_VERSION < NPY_1_7_API_VERSION
   PyArray_BASE(array) = cap;
 %#else
   PyArray_SetBaseObject(array,cap);
@@ -2809,13 +2777,9 @@
 
   if (!array) SWIG_fail;
 
-%#ifdef SWIGPY_USE_CAPSULE
-    PyObject* cap = PyCapsule_New((void*)(*$1), SWIGPY_CAPSULE_NAME, free_cap);
-%#else
-    PyObject* cap = PyCObject_FromVoidPtr((void*)(*$1), free);
-%#endif
+PyObject* cap = PyCapsule_New((void*)(*$1), SWIGPY_CAPSULE_NAME, free_cap);
 
-%#if NPY_API_VERSION < 0x00000007
+%#if NPY_API_VERSION < NPY_1_7_API_VERSION
   PyArray_BASE(array) = cap;
 %#else
   PyArray_SetBaseObject(array,cap);
@@ -2847,165 +2811,9 @@
 
   if (!array) SWIG_fail;
 
-%#ifdef SWIGPY_USE_CAPSULE
-    PyObject* cap = PyCapsule_New((void*)(*$1), SWIGPY_CAPSULE_NAME, free_cap);
-%#else
-    PyObject* cap = PyCObject_FromVoidPtr((void*)(*$1), free);
-%#endif
+PyObject* cap = PyCapsule_New((void*)(*$5), SWIGPY_CAPSULE_NAME, free_cap);
 
-%#if NPY_API_VERSION < 0x00000007
-  PyArray_BASE(array) = cap;
-%#else
-  PyArray_SetBaseObject(array,cap);
-%#endif
-
-  $result = SWIG_Python_AppendOutput($result,obj);
-}
-
-/* Typemap suite for (DATA_TYPE** ARGOUTVIEWM_FARRAY4, DIM_TYPE* DIM1, DIM_TYPE* DIM2,
-                      DIM_TYPE* DIM3, DIM_TYPE* DIM4)
- */
-%typemap(in,numinputs=0)
-  (DATA_TYPE** ARGOUTVIEWM_FARRAY4, DIM_TYPE* DIM1    , DIM_TYPE* DIM2    , DIM_TYPE* DIM3    , DIM_TYPE* DIM4    )
-  (DATA_TYPE* data_temp = NULL    , DIM_TYPE dim1_temp, DIM_TYPE dim2_temp, DIM_TYPE dim3_temp, DIM_TYPE dim4_temp)
-{
-  $1 = &data_temp;
-  $2 = &dim1_temp;
-  $3 = &dim2_temp;
-  $4 = &dim3_temp;
-  $5 = &dim4_temp;
-}
-%typemap(argout,
-         fragment="NumPy_Backward_Compatibility,NumPy_Array_Requirements,NumPy_Utilities")
-  (DATA_TYPE** ARGOUTVIEWM_FARRAY4, DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3)
-{
-  npy_intp dims[4] = { *$2, *$3, *$4 , *$5 };
-  PyObject* obj = PyArray_SimpleNewFromData(4, dims, DATA_TYPECODE, (void*)(*$1));
-  PyArrayObject* array = (PyArrayObject*) obj;
-
-  if (!array || !require_fortran(array)) SWIG_fail;
-
-%#ifdef SWIGPY_USE_CAPSULE
-    PyObject* cap = PyCapsule_New((void*)(*$1), SWIGPY_CAPSULE_NAME, free_cap);
-%#else
-    PyObject* cap = PyCObject_FromVoidPtr((void*)(*$1), free);
-%#endif
-
-%#if NPY_API_VERSION < 0x00000007
-  PyArray_BASE(array) = cap;
-%#else
-  PyArray_SetBaseObject(array,cap);
-%#endif
-
-  $result = SWIG_Python_AppendOutput($result,obj);
-}
-
-/* Typemap suite for (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3, DIM_TYPE* DIM4,
-                      DATA_TYPE** ARGOUTVIEWM_FARRAY4)
- */
-%typemap(in,numinputs=0)
-  (DIM_TYPE* DIM1    , DIM_TYPE* DIM2    , DIM_TYPE* DIM3    , DIM_TYPE* DIM4    , DATA_TYPE** ARGOUTVIEWM_FARRAY4)
-  (DIM_TYPE dim1_temp, DIM_TYPE dim2_temp, DIM_TYPE dim3_temp, DIM_TYPE dim4_temp, DATA_TYPE* data_temp = NULL    )
-{
-  $1 = &dim1_temp;
-  $2 = &dim2_temp;
-  $3 = &dim3_temp;
-  $4 = &dim4_temp;
-  $5 = &data_temp;
-}
-%typemap(argout,
-         fragment="NumPy_Backward_Compatibility,NumPy_Array_Requirements,NumPy_Utilities")
-  (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3, DIM_TYPE* DIM4, DATA_TYPE** ARGOUTVIEWM_FARRAY4)
-{
-  npy_intp dims[4] = { *$1, *$2, *$3 , *$4 };
-  PyObject* obj = PyArray_SimpleNewFromData(4, dims, DATA_TYPECODE, (void*)(*$5));
-  PyArrayObject* array = (PyArrayObject*) obj;
-
-  if (!array || !require_fortran(array)) SWIG_fail;
-
-%#ifdef SWIGPY_USE_CAPSULE
-    PyObject* cap = PyCapsule_New((void*)(*$1), SWIGPY_CAPSULE_NAME, free_cap);
-%#else
-    PyObject* cap = PyCObject_FromVoidPtr((void*)(*$1), free);
-%#endif
-
-%#if NPY_API_VERSION < 0x00000007
-  PyArray_BASE(array) = cap;
-%#else
-  PyArray_SetBaseObject(array,cap);
-%#endif
-
-  $result = SWIG_Python_AppendOutput($result,obj);
-}
-
-/* Typemap suite for (DATA_TYPE** ARGOUTVIEWM_ARRAY4, DIM_TYPE* DIM1, DIM_TYPE* DIM2,
-                      DIM_TYPE* DIM3, DIM_TYPE* DIM4)
- */
-%typemap(in,numinputs=0)
-  (DATA_TYPE** ARGOUTVIEWM_ARRAY4, DIM_TYPE* DIM1    , DIM_TYPE* DIM2    , DIM_TYPE* DIM3    , DIM_TYPE* DIM4    )
-  (DATA_TYPE* data_temp = NULL   , DIM_TYPE dim1_temp, DIM_TYPE dim2_temp, DIM_TYPE dim3_temp, DIM_TYPE dim4_temp)
-{
-  $1 = &data_temp;
-  $2 = &dim1_temp;
-  $3 = &dim2_temp;
-  $4 = &dim3_temp;
-  $5 = &dim4_temp;
-}
-%typemap(argout,
-         fragment="NumPy_Backward_Compatibility,NumPy_Utilities")
-  (DATA_TYPE** ARGOUTVIEWM_ARRAY4, DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3, DIM_TYPE* DIM4)
-{
-  npy_intp dims[4] = { *$2, *$3, *$4 , *$5 };
-  PyObject* obj = PyArray_SimpleNewFromData(4, dims, DATA_TYPECODE, (void*)(*$1));
-  PyArrayObject* array = (PyArrayObject*) obj;
-
-  if (!array) SWIG_fail;
-
-%#ifdef SWIGPY_USE_CAPSULE
-    PyObject* cap = PyCapsule_New((void*)(*$1), SWIGPY_CAPSULE_NAME, free_cap);
-%#else
-    PyObject* cap = PyCObject_FromVoidPtr((void*)(*$1), free);
-%#endif
-
-%#if NPY_API_VERSION < 0x00000007
-  PyArray_BASE(array) = cap;
-%#else
-  PyArray_SetBaseObject(array,cap);
-%#endif
-
-  $result = SWIG_Python_AppendOutput($result,obj);
-}
-
-/* Typemap suite for (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3, DIM_TYPE* DIM4,
-                      DATA_TYPE** ARGOUTVIEWM_ARRAY4)
- */
-%typemap(in,numinputs=0)
-  (DIM_TYPE* DIM1    , DIM_TYPE* DIM2    , DIM_TYPE* DIM3    , DIM_TYPE* DIM4    , DATA_TYPE** ARGOUTVIEWM_ARRAY4)
-  (DIM_TYPE dim1_temp, DIM_TYPE dim2_temp, DIM_TYPE dim3_temp, DIM_TYPE dim4_temp, DATA_TYPE* data_temp = NULL   )
-{
-  $1 = &dim1_temp;
-  $2 = &dim2_temp;
-  $3 = &dim3_temp;
-  $4 = &dim4_temp;
-  $5 = &data_temp;
-}
-%typemap(argout,
-         fragment="NumPy_Backward_Compatibility,NumPy_Utilities")
-  (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3, DIM_TYPE* DIM4, DATA_TYPE** ARGOUTVIEWM_ARRAY4)
-{
-  npy_intp dims[4] = { *$1, *$2, *$3 , *$4 };
-  PyObject* obj = PyArray_SimpleNewFromData(4, dims, DATA_TYPECODE, (void*)(*$5));
-  PyArrayObject* array = (PyArrayObject*) obj;
-
-  if (!array) SWIG_fail;
-
-%#ifdef SWIGPY_USE_CAPSULE
-    PyObject* cap = PyCapsule_New((void*)(*$1), SWIGPY_CAPSULE_NAME, free_cap);
-%#else
-    PyObject* cap = PyCObject_FromVoidPtr((void*)(*$1), free);
-%#endif
-
-%#if NPY_API_VERSION < 0x00000007
+%#if NPY_API_VERSION < NPY_1_7_API_VERSION
   PyArray_BASE(array) = cap;
 %#else
   PyArray_SetBaseObject(array,cap);
@@ -3037,13 +2845,9 @@
 
   if (!array || !require_fortran(array)) SWIG_fail;
 
-%#ifdef SWIGPY_USE_CAPSULE
-    PyObject* cap = PyCapsule_New((void*)(*$1), SWIGPY_CAPSULE_NAME, free_cap);
-%#else
-    PyObject* cap = PyCObject_FromVoidPtr((void*)(*$1), free);
-%#endif
+PyObject* cap = PyCapsule_New((void*)(*$1), SWIGPY_CAPSULE_NAME, free_cap);
 
-%#if NPY_API_VERSION < 0x00000007
+%#if NPY_API_VERSION < NPY_1_7_API_VERSION
   PyArray_BASE(array) = cap;
 %#else
   PyArray_SetBaseObject(array,cap);
@@ -3075,13 +2879,9 @@
 
   if (!array || !require_fortran(array)) SWIG_fail;
 
-%#ifdef SWIGPY_USE_CAPSULE
-    PyObject* cap = PyCapsule_New((void*)(*$1), SWIGPY_CAPSULE_NAME, free_cap);
-%#else
-    PyObject* cap = PyCObject_FromVoidPtr((void*)(*$1), free);
-%#endif
+PyObject* cap = PyCapsule_New((void*)(*$5), SWIGPY_CAPSULE_NAME, free_cap);
 
-%#if NPY_API_VERSION < 0x00000007
+%#if NPY_API_VERSION < NPY_1_7_API_VERSION
   PyArray_BASE(array) = cap;
 %#else
   PyArray_SetBaseObject(array,cap);
@@ -3134,6 +2934,15 @@
 %numpy_typemaps(unsigned long long, NPY_ULONGLONG, int)
 %numpy_typemaps(float             , NPY_FLOAT    , int)
 %numpy_typemaps(double            , NPY_DOUBLE   , int)
+%numpy_typemaps(int8_t            , NPY_INT8     , int)
+%numpy_typemaps(int16_t           , NPY_INT16    , int)
+%numpy_typemaps(int32_t           , NPY_INT32    , int)
+%numpy_typemaps(int64_t           , NPY_INT64    , int)
+%numpy_typemaps(uint8_t           , NPY_UINT8    , int)
+%numpy_typemaps(uint16_t          , NPY_UINT16   , int)
+%numpy_typemaps(uint32_t          , NPY_UINT32   , int)
+%numpy_typemaps(uint64_t          , NPY_UINT64   , int)
+
 
 /* ***************************************************************
  * The follow macro expansion does not work, because C++ bool is 4

--- a/setup.py.in
+++ b/setup.py.in
@@ -26,14 +26,23 @@ except ImportError:
     msg += "(You may need to active a virtual environment before running this.)"
     raise Exception(msg)
 else:
-    numpy_include_path = Path(np.__file__).parent.joinpath("_core", "include")
-    arrayobject_file = numpy_include_path.joinpath("numpy", "arrayobject.h")
-    if not arrayobject_file.exists():
-        msg = f"Could not find numpy/arrayobjcet.h in {numpy_include_path}. "
+    numpy_dir = Path(np.__file__).parent
+    core_dirs = ["_core", "core"]
+    valid_path_found = False
+    for core_dir in core_dirs:
+        numpy_include_path = numpy_dir.joinpath(core_dir, "include")
+        arrayobject_file = numpy_include_path.joinpath("numpy", "arrayobject.h")
+        if arrayobject_file.exists():
+            valid_path_found = True
+            break
+
+    if not valid_path_found:
+        msg = f"Could not find numpy/arrayobject.h in 'core' or '_core' in . "
         msg += "Build will fail. "
         raise Exception(msg)
     else:
         print(f"Using {numpy_include_path=}")
+
     numpy_include_path = str(numpy_include_path)
 
 package_name = 'detectorbank'

--- a/setup.py.in
+++ b/setup.py.in
@@ -16,6 +16,25 @@ debug = 0
 from setuptools import setup, Extension, Command
 from setuptools.command.build_ext import build_ext as _build_ext
 import os
+from pathlib import Path
+
+try:
+    import numpy as np
+except ImportError:
+    msg = "Building DetectorBank python extension requires numpy. "
+    msg += "Please ensure numpy is installed. "
+    msg += "(You may need to active a virtual environment before running this.)"
+    raise Exception(msg)
+else:
+    numpy_include_path = Path(np.__file__).parent.joinpath("_core", "include")
+    arrayobject_file = numpy_include_path.joinpath("numpy", "arrayobject.h")
+    if not arrayobject_file.exists():
+        msg = f"Could not find numpy/arrayobjcet.h in {numpy_include_path}. "
+        msg += "Build will fail. "
+        raise Exception(msg)
+    else:
+        print(f"Using {numpy_include_path=}")
+    numpy_include_path = str(numpy_include_path)
 
 package_name = 'detectorbank'
 
@@ -35,7 +54,7 @@ detectorbank = Extension(
     sources              = ['detectorbank_wrap.cpp'],
     language             = 'c++',
     undef_macros         = ['NDEBUG'],
-    include_dirs         = ['@abs_top_srcdir@/src'],
+    include_dirs         = ['@abs_top_srcdir@/src', numpy_include_path],
     library_dirs         = ['@abs_top_builddir@/src/.libs'],
     runtime_library_dirs = ['@libdir@'],
     libraries            = libs

--- a/test/Pytests.in
+++ b/test/Pytests.in
@@ -1,17 +1,8 @@
 #!@SHELL@
 
 # Tests are run on the newly built _detectorbank extension,
-# which resides in an arch-dependent build directory one
-# under ../build. We need to know that directory so the
-# directory can be loaded from there.
-# Also, the library has been built in the source directory
-# under .libs at this point, but not installed.
-#sharedobj=$(find ../build -name _detectorbank\*)
-#export LD_LIBRARY_PATH=../src/.libs
-
-# Similarly, test the newly built detectorbank.py,
-# not some previously installed one.
-#export PYTHONPATH=..:@srcdir@:$(dirname $sharedobj)
+# which is installed into a local python virtual environment
+# from the wheel which has been built already.
 
 echo "using srcdir = @srcdir@; PYTHONPATH=$PYTHONPATH; LD_LIBRARY_PATH=$LD_LIBRARY_PATH"
 echo "WD now $PWD"
@@ -24,6 +15,16 @@ if [ -z $whl ]; then
   echo "Unable to find python wheel in ../dist"
   exit 1
 else
+  restore_env ()  {
+    deactivate
+    if [ ! -z $dev_venv ] ; then
+      echo "Restoring original virtual environment $dev_venv"
+      source "$dev_venv/bin/activate"
+    fi
+  }
+  trap restore_env EXIT
+  dev_venv="$VIRTUAL_ENV"
+  [ -z "$dev_venv" ] && deactivate
   echo "Creating venv..."
   if [ -d $venv_dir ]; then
     rm -rf $venv_dir

--- a/test/Pytests.in
+++ b/test/Pytests.in
@@ -6,12 +6,12 @@
 # directory can be loaded from there.
 # Also, the library has been built in the source directory
 # under .libs at this point, but not installed.
-sharedobj=$(find ../build -name _detectorbank\*)
-export LD_LIBRARY_PATH=../src/.libs
+#sharedobj=$(find ../build -name _detectorbank\*)
+#export LD_LIBRARY_PATH=../src/.libs
 
 # Similarly, test the newly built detectorbank.py,
 # not some previously installed one.
-export PYTHONPATH=..:@srcdir@:$(dirname $sharedobj)
+#export PYTHONPATH=..:@srcdir@:$(dirname $sharedobj)
 
 echo "using srcdir = @srcdir@; PYTHONPATH=$PYTHONPATH; LD_LIBRARY_PATH=$LD_LIBRARY_PATH"
 echo "WD now $PWD"


### PR DESCRIPTION
Changes to Pytests.in so that it remembers what venv it was on entry, deactivates it before testing, and reactivates the old environment afterwards. It traps the EXIT signal so with with luck the original environment should be restored even if there's a hard crash.

Comments changed to reflect new operation, and harmful changes to environment variables removed.

Please check AOK w.r.t. logic and pythonesqness.

Also: changed Makefile.am to split generation of python library and wheels. This allows for graceful continuation if, for example. the wheel generation failed after the library generation. Previously, under these circumstances, you'd need to make clean to get the whole package built.